### PR TITLE
ユーザー編集機能から、パスワードのフォームを削除

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   validates :nickname, presence: true
 
   PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
-  validates_format_of :password, with: PASSWORD_REGEX, message: 'is invalid. Must contain both letters and numbers'
+  validates_format_of :password, with: PASSWORD_REGEX, message: 'is invalid. Must contain both letters and numbers', on: :create
 
   with_options presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'Input full-width characters' } do
     validates :last_name

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -21,12 +21,6 @@
     </div>
     <%= f.email_field :email, class:"input-default", id:"email", placeholder:"PC・携帯どちらでも可" %>
   </div>
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">新しいパスワード</label>
-    </div>
-    <%= f.password_field :password, class:"input-default", id:"password"%>
-  </div>
     <div class='login-btn'>
       <%= f.submit "編集内容を更新" ,class:"login-red-btn" %>
     </div>

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -22,11 +22,6 @@ RSpec.describe "Users", type: :request do
       get edit_user_path(@user)
       expect(response.body).to include("新しいメールアドレス")
     end
-    it 'editアクションにリクエストするとレスポンスに新しいパスワードの入力フォームが存在する' do 
-      @user.save
-      get edit_user_path(@user)
-      expect(response.body).to include("新しいパスワード")
-    end
   end 
 
 


### PR DESCRIPTION
#what
ユーザー編集機能から、パスワードのフォームを削除
#why
マイページに入るたびに、パスワードの入力を求められる。変更の必要のない時も入力をしないといけないので無駄な作業を無くすために、パスワードの入力フォームを削除